### PR TITLE
Feat: Aceita certificado em base64

### DIFF
--- a/examples/cenvert-certificate.ts
+++ b/examples/cenvert-certificate.ts
@@ -1,0 +1,20 @@
+import { PathLike, readFileSync } from 'fs';
+
+export default function certificateToBase64(pathCert: PathLike) {
+	try {
+		const hasCertificateValid = pathCert.toString().endsWith('.pem') || pathCert.toString().endsWith('.p12');
+		if (!hasCertificateValid) {
+			throw new Error('O certificado deve ser .pem ou .p12');
+		}
+		const certification = readFileSync(pathCert);
+
+		const base64 = Buffer.from(certification).toString('base64');
+
+		return base64;
+	} catch (err) {
+		if (err instanceof Error) {
+			return err.message;
+		}
+		throw new Error(err);
+	}
+}

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/extensions */
-import Endpoints from './src/endpoints';
 import constants from './src/constants';
+import Endpoints from './src/endpoints';
 import { EfiConfig } from './src/interfaces/efiConfig.interface';
 import { EfiCredentials } from './src/interfaces/efiCredentials.interface';
 
@@ -14,15 +14,20 @@ class EfiPay {
 			options.certificate = options.pathCert || options.pix_cert;
 		}
 
+		if (options.cert_base64 && typeof options.certificate === 'string') {
+			options.certificate = Buffer.from(options.certificate, 'base64');
+		}
+
 		const credentials: EfiConfig = {
 			client_id: options.client_id,
 			client_secret: options.client_secret,
 			certificate: options.certificate,
+			cert_base64: options.cert_base64,
 			sandbox: options.sandbox,
 		};
 
-		if(options.pemKey){
-			credentials.pemKey = options.pemKey
+		if (options.pemKey) {
+			credentials.pemKey = options.pemKey;
 		}
 
 		const methods = {};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "npx tsc -p ./tsconfig.json",
+    "build": "rm -rf dist && npx tsc",
     "prepare": "npm run build",
     "postversion": "git push --tags",
     "test": "./node_modules/.bin/jest",

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/extensions */
+import axios from 'axios';
 import fs from 'fs';
 import https from 'https';
-import axios from 'axios';
-import Auth from './auth';
 import sdkPackage from '../package.json';
+import Auth from './auth';
 import { EfiConfig } from './interfaces/efiConfig.interface';
 import { EndpointInterface } from './interfaces/endpoint.interface';
 
@@ -40,15 +40,15 @@ class Endpoints {
 
 			try {
 				if (this.options.certificate) {
-					if(this.options.pemKey){
+					if (this.options.pemKey) {
 						this.agent = new https.Agent({
-							cert:  fs.readFileSync(this.options.certificate),
-							key:  fs.readFileSync(this.options.pemKey),
+							cert: fs.readFileSync(this.options.certificate),
+							key: fs.readFileSync(this.options.pemKey),
 							passphrase: '',
 						});
-					}else{
+					} else {
 						this.agent = new https.Agent({
-							pfx: fs.readFileSync(this.options.certificate),
+							pfx: this.options.cert_base64 && this.options.certificate instanceof Buffer ? this.options.certificate : fs.readFileSync(this.options.certificate),
 							passphrase: '',
 						});
 					}

--- a/src/interfaces/efiConfig.interface.ts
+++ b/src/interfaces/efiConfig.interface.ts
@@ -7,6 +7,7 @@ export interface EfiConfig {
 	client_id: string;
 	client_secret: string;
 	certificate?: PathLike | string;
+	cert_base64?: boolean;
 	pemKey?: PathLike | string;
 	sandbox: boolean;
 	partnerToken?: string;

--- a/src/interfaces/efiCredentials.interface.ts
+++ b/src/interfaces/efiCredentials.interface.ts
@@ -5,6 +5,7 @@ export interface EfiCredentials {
 	client_id: string;
 	client_secret: string;
 	certificate?: PathLike | string;
+	cert_base64?: boolean;
 	pix_cert?: PathLike | string;
 	pathCert?: PathLike | string;
 	pemKey?: PathLike | string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,8 @@
     "resolveJsonModule": true
   },
   "exclude": [
-    "examples"
+    "examples",
+    "node_modules",
+    "dist"
   ]
 }


### PR DESCRIPTION
# Certificado via variável de ambiente

Adiciona uma nova chave `cert_base64` nas interfaces `EfiConfig` e `EfiCredentials` para sinalizar quem irá passar um certificado convertido em base64 na chave `certificate` das opções do construtor da classe EfiPay.

Na classe EfiPay dentro o construtor verifico de foi passado o parâmetro `cert-base64` como `true` e converto para um Buffer e atribuo novamente no parâmetro `certificate`.

Na classe Endpoint antes de criar um agent http verifico de se o certificado foi passado como base64 e assim injeto o atributo cerificado no http agente para não tentar ler um path de certificado que não existe.


Exemplo de uso:
```typescript
import EfiPay from 'sdk-typescript-apis-efi'

const certBase64 = process.env.EFI_CERT_BASE64 // aqui já foi inserido um certificado convertido em base64

const efiPay = new EfiPay({
  sandbox: false,
  client_id: 'client_id',
  client_secret: 'client_secret',
  certificate: certBase64,
  cert_base64: true
})
```
