### PR TITLE
fix: resolve ts(2351) import error in ESM and update typescript to v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ simulaMod.ts
 npm-debug.log
 coverage/
 .idea/
+.agent/

--- a/dist/cjs/index.cjs
+++ b/dist/cjs/index.cjs
@@ -579,7 +579,7 @@ var types = "dist/types/index.d.ts";
 var exports$1 = {
 	".": {
 		require: "./dist/cjs/index.cjs",
-		"import": "./dist/cjs/index.cjs",
+		"import": "./dist/esm/index.mjs",
 		types: "./dist/types/index.d.ts"
 	}
 };
@@ -614,6 +614,7 @@ var dependencies = {
 var scripts = {
 	start: "node app.js",
 	build: "rollup -c && tsc --project tsconfig.json",
+	postbuild: "node fix-types.js",
 	test: "./node_modules/.bin/jest",
 	"test-cov": "./node_modules/.bin/jest --coverage"
 };
@@ -624,7 +625,7 @@ var devDependencies = {
 	"@rollup/plugin-json": "^6.1.0",
 	prettier: "^3.0.3",
 	rollup: "^2.52.3",
-	typescript: "^4.3.5",
+	typescript: "^5.9.3",
 	undici: "^6.19.2"
 };
 var sdkPackage = {

--- a/dist/esm/index.mjs
+++ b/dist/esm/index.mjs
@@ -570,7 +570,7 @@ var types = "dist/types/index.d.ts";
 var exports = {
 	".": {
 		require: "./dist/cjs/index.cjs",
-		"import": "./dist/cjs/index.cjs",
+		"import": "./dist/esm/index.mjs",
 		types: "./dist/types/index.d.ts"
 	}
 };
@@ -605,6 +605,7 @@ var dependencies = {
 var scripts = {
 	start: "node app.js",
 	build: "rollup -c && tsc --project tsconfig.json",
+	postbuild: "node fix-types.js",
 	test: "./node_modules/.bin/jest",
 	"test-cov": "./node_modules/.bin/jest --coverage"
 };
@@ -615,7 +616,7 @@ var devDependencies = {
 	"@rollup/plugin-json": "^6.1.0",
 	prettier: "^3.0.3",
 	rollup: "^2.52.3",
-	typescript: "^4.3.5",
+	typescript: "^5.9.3",
 	undici: "^6.19.2"
 };
 var sdkPackage = {

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -1,4 +1,4 @@
-export default class EfiPay extends AllMethods {
+declare class EfiPay extends AllMethods {
     /**
      * Construtor da classe EfiPay.
      * @param {Object} options - Objeto com opções de configuração e credenciais.
@@ -30,3 +30,5 @@ export default class EfiPay extends AllMethods {
     });
 }
 import { AllMethods } from "./methods/index";
+
+export = EfiPay;

--- a/dist/types/lib/constants.d.ts
+++ b/dist/types/lib/constants.d.ts
@@ -2,618 +2,618 @@ declare namespace _default {
     namespace APIS {
         namespace DEFAULT {
             namespace URL {
-                const PRODUCTION: string;
-                const SANDBOX: string;
+                let PRODUCTION: string;
+                let SANDBOX: string;
             }
             namespace ENDPOINTS {
                 namespace authorize {
-                    const route: string;
-                    const method: string;
+                    let route: string;
+                    let method: string;
                 }
                 namespace sendSubscriptionLinkEmail {
-                    const route_1: string;
+                    let route_1: string;
                     export { route_1 as route };
-                    const method_1: string;
+                    let method_1: string;
                     export { method_1 as method };
                 }
                 namespace oneStepSubscription {
-                    const route_2: string;
+                    let route_2: string;
                     export { route_2 as route };
-                    const method_2: string;
+                    let method_2: string;
                     export { method_2 as method };
                 }
                 namespace settleCarnet {
-                    const route_3: string;
+                    let route_3: string;
                     export { route_3 as route };
-                    const method_3: string;
+                    let method_3: string;
                     export { method_3 as method };
                 }
                 namespace oneStepSubscriptionLink {
-                    const route_4: string;
+                    let route_4: string;
                     export { route_4 as route };
-                    const method_4: string;
+                    let method_4: string;
                     export { method_4 as method };
                 }
                 namespace sendLinkEmail {
-                    const route_5: string;
+                    let route_5: string;
                     export { route_5 as route };
-                    const method_5: string;
+                    let method_5: string;
                     export { method_5 as method };
                 }
                 namespace createOneStepLink {
-                    const route_6: string;
+                    let route_6: string;
                     export { route_6 as route };
-                    const method_6: string;
+                    let method_6: string;
                     export { method_6 as method };
                 }
                 namespace createCharge {
-                    const route_7: string;
+                    let route_7: string;
                     export { route_7 as route };
-                    const method_7: string;
+                    let method_7: string;
                     export { method_7 as method };
                 }
                 namespace detailCharge {
-                    const route_8: string;
+                    let route_8: string;
                     export { route_8 as route };
-                    const method_8: string;
+                    let method_8: string;
                     export { method_8 as method };
                 }
                 namespace updateChargeMetadata {
-                    const route_9: string;
+                    let route_9: string;
                     export { route_9 as route };
-                    const method_9: string;
+                    let method_9: string;
                     export { method_9 as method };
                 }
                 namespace updateBillet {
-                    const route_10: string;
+                    let route_10: string;
                     export { route_10 as route };
-                    const method_10: string;
+                    let method_10: string;
                     export { method_10 as method };
                 }
                 namespace definePayMethod {
-                    const route_11: string;
+                    let route_11: string;
                     export { route_11 as route };
-                    const method_11: string;
+                    let method_11: string;
                     export { method_11 as method };
                 }
                 namespace cancelCharge {
-                    const route_12: string;
+                    let route_12: string;
                     export { route_12 as route };
-                    const method_12: string;
+                    let method_12: string;
                     export { method_12 as method };
                 }
                 namespace createCarnet {
-                    const route_13: string;
+                    let route_13: string;
                     export { route_13 as route };
-                    const method_13: string;
+                    let method_13: string;
                     export { method_13 as method };
                 }
                 namespace detailCarnet {
-                    const route_14: string;
+                    let route_14: string;
                     export { route_14 as route };
-                    const method_14: string;
+                    let method_14: string;
                     export { method_14 as method };
                 }
                 namespace updateCarnetParcel {
-                    const route_15: string;
+                    let route_15: string;
                     export { route_15 as route };
-                    const method_15: string;
+                    let method_15: string;
                     export { method_15 as method };
                 }
                 namespace updateCarnetParcels {
-                    const route_16: string;
+                    let route_16: string;
                     export { route_16 as route };
-                    const method_16: string;
+                    let method_16: string;
                     export { method_16 as method };
                 }
                 namespace updateCarnetMetadata {
-                    const route_17: string;
+                    let route_17: string;
                     export { route_17 as route };
-                    const method_17: string;
+                    let method_17: string;
                     export { method_17 as method };
                 }
                 namespace getNotification {
-                    const route_18: string;
+                    let route_18: string;
                     export { route_18 as route };
-                    const method_18: string;
+                    let method_18: string;
                     export { method_18 as method };
                 }
                 namespace listPlans {
-                    const route_19: string;
+                    let route_19: string;
                     export { route_19 as route };
-                    const method_19: string;
+                    let method_19: string;
                     export { method_19 as method };
                 }
                 namespace createPlan {
-                    const route_20: string;
+                    let route_20: string;
                     export { route_20 as route };
-                    const method_20: string;
+                    let method_20: string;
                     export { method_20 as method };
                 }
                 namespace deletePlan {
-                    const route_21: string;
+                    let route_21: string;
                     export { route_21 as route };
-                    const method_21: string;
+                    let method_21: string;
                     export { method_21 as method };
                 }
                 namespace createSubscription {
-                    const route_22: string;
+                    let route_22: string;
                     export { route_22 as route };
-                    const method_22: string;
+                    let method_22: string;
                     export { method_22 as method };
                 }
                 namespace createOneStepSubscription {
-                    const route_23: string;
+                    let route_23: string;
                     export { route_23 as route };
-                    const method_23: string;
+                    let method_23: string;
                     export { method_23 as method };
                 }
                 namespace createOneStepSubscriptionLink {
-                    const route_24: string;
+                    let route_24: string;
                     export { route_24 as route };
-                    const method_24: string;
+                    let method_24: string;
                     export { method_24 as method };
                 }
                 namespace detailSubscription {
-                    const route_25: string;
+                    let route_25: string;
                     export { route_25 as route };
-                    const method_25: string;
+                    let method_25: string;
                     export { method_25 as method };
                 }
                 namespace defineSubscriptionPayMethod {
-                    const route_26: string;
+                    let route_26: string;
                     export { route_26 as route };
-                    const method_26: string;
+                    let method_26: string;
                     export { method_26 as method };
                 }
                 namespace cancelSubscription {
-                    const route_27: string;
+                    let route_27: string;
                     export { route_27 as route };
-                    const method_27: string;
+                    let method_27: string;
                     export { method_27 as method };
                 }
                 namespace updateSubscriptionMetadata {
-                    const route_28: string;
+                    let route_28: string;
                     export { route_28 as route };
-                    const method_28: string;
+                    let method_28: string;
                     export { method_28 as method };
                 }
                 namespace getInstallments {
-                    const route_29: string;
+                    let route_29: string;
                     export { route_29 as route };
-                    const method_29: string;
+                    let method_29: string;
                     export { method_29 as method };
                 }
                 namespace sendBilletEmail {
-                    const route_30: string;
+                    let route_30: string;
                     export { route_30 as route };
-                    const method_30: string;
+                    let method_30: string;
                     export { method_30 as method };
                 }
                 namespace createChargeHistory {
-                    const route_31: string;
+                    let route_31: string;
                     export { route_31 as route };
-                    const method_31: string;
+                    let method_31: string;
                     export { method_31 as method };
                 }
                 namespace sendCarnetEmail {
-                    const route_32: string;
+                    let route_32: string;
                     export { route_32 as route };
-                    const method_32: string;
+                    let method_32: string;
                     export { method_32 as method };
                 }
                 namespace sendCarnetParcelEmail {
-                    const route_33: string;
+                    let route_33: string;
                     export { route_33 as route };
-                    const method_33: string;
+                    let method_33: string;
                     export { method_33 as method };
                 }
                 namespace createCarnetHistory {
-                    const route_34: string;
+                    let route_34: string;
                     export { route_34 as route };
-                    const method_34: string;
+                    let method_34: string;
                     export { method_34 as method };
                 }
                 namespace cancelCarnet {
-                    const route_35: string;
+                    let route_35: string;
                     export { route_35 as route };
-                    const method_35: string;
+                    let method_35: string;
                     export { method_35 as method };
                 }
                 namespace cancelCarnetParcel {
-                    const route_36: string;
+                    let route_36: string;
                     export { route_36 as route };
-                    const method_36: string;
+                    let method_36: string;
                     export { method_36 as method };
                 }
                 namespace linkCharge {
-                    const route_37: string;
+                    let route_37: string;
                     export { route_37 as route };
-                    const method_37: string;
+                    let method_37: string;
                     export { method_37 as method };
                 }
                 namespace defineLinkPayMethod {
-                    const route_38: string;
+                    let route_38: string;
                     export { route_38 as route };
-                    const method_38: string;
+                    let method_38: string;
                     export { method_38 as method };
                 }
                 namespace updateChargeLink {
-                    const route_39: string;
+                    let route_39: string;
                     export { route_39 as route };
-                    const method_39: string;
+                    let method_39: string;
                     export { method_39 as method };
                 }
                 namespace updatePlan {
-                    const route_40: string;
+                    let route_40: string;
                     export { route_40 as route };
-                    const method_40: string;
+                    let method_40: string;
                     export { method_40 as method };
                 }
                 namespace updateSubscription {
-                    const route_41: string;
+                    let route_41: string;
                     export { route_41 as route };
-                    const method_41: string;
+                    let method_41: string;
                     export { method_41 as method };
                 }
                 namespace createSubscriptionHistory {
-                    const route_42: string;
+                    let route_42: string;
                     export { route_42 as route };
-                    const method_42: string;
+                    let method_42: string;
                     export { method_42 as method };
                 }
                 namespace defineBalanceSheetBillet {
-                    const route_43: string;
+                    let route_43: string;
                     export { route_43 as route };
-                    const method_43: string;
+                    let method_43: string;
                     export { method_43 as method };
                 }
                 namespace settleCharge {
-                    const route_44: string;
+                    let route_44: string;
                     export { route_44 as route };
-                    const method_44: string;
+                    let method_44: string;
                     export { method_44 as method };
                 }
                 namespace settleCarnetParcel {
-                    const route_45: string;
+                    let route_45: string;
                     export { route_45 as route };
-                    const method_45: string;
+                    let method_45: string;
                     export { method_45 as method };
                 }
                 namespace createOneStepCharge {
-                    const route_46: string;
+                    let route_46: string;
                     export { route_46 as route };
-                    const method_46: string;
+                    let method_46: string;
                     export { method_46 as method };
                 }
                 namespace cardPaymentRetry {
-                    const route_47: string;
+                    let route_47: string;
                     export { route_47 as route };
-                    const method_47: string;
+                    let method_47: string;
                     export { method_47 as method };
                 }
                 namespace refundCard {
-                    const route_48: string;
+                    let route_48: string;
                     export { route_48 as route };
-                    const method_48: string;
+                    let method_48: string;
                     export { method_48 as method };
                 }
                 namespace listCharges {
-                    const route_49: string;
+                    let route_49: string;
                     export { route_49 as route };
-                    const method_49: string;
+                    let method_49: string;
                     export { method_49 as method };
                 }
             }
         }
         namespace PIX {
             export namespace URL_1 {
-                const PRODUCTION_1: string;
+                let PRODUCTION_1: string;
                 export { PRODUCTION_1 as PRODUCTION };
-                const SANDBOX_1: string;
+                let SANDBOX_1: string;
                 export { SANDBOX_1 as SANDBOX };
             }
             export { URL_1 as URL };
             export namespace ENDPOINTS_1 {
                 export namespace authorize_1 {
-                    const route_50: string;
+                    let route_50: string;
                     export { route_50 as route };
-                    const method_50: string;
+                    let method_50: string;
                     export { method_50 as method };
                 }
                 export { authorize_1 as authorize };
                 export namespace pixCreateDueCharge {
-                    const route_51: string;
+                    let route_51: string;
                     export { route_51 as route };
-                    const method_51: string;
+                    let method_51: string;
                     export { method_51 as method };
                 }
                 export namespace pixUpdateDueCharge {
-                    const route_52: string;
+                    let route_52: string;
                     export { route_52 as route };
-                    const method_52: string;
+                    let method_52: string;
                     export { method_52 as method };
                 }
                 export namespace pixDetailDueCharge {
-                    const route_53: string;
+                    let route_53: string;
                     export { route_53 as route };
-                    const method_53: string;
+                    let method_53: string;
                     export { method_53 as method };
                 }
                 export namespace pixListDueCharges {
-                    const route_54: string;
+                    let route_54: string;
                     export { route_54 as route };
-                    const method_54: string;
+                    let method_54: string;
                     export { method_54 as method };
                 }
                 export namespace createReport {
-                    const route_55: string;
+                    let route_55: string;
                     export { route_55 as route };
-                    const method_55: string;
+                    let method_55: string;
                     export { method_55 as method };
                 }
                 export namespace detailReport {
-                    const route_56: string;
+                    let route_56: string;
                     export { route_56 as route };
-                    const method_56: string;
+                    let method_56: string;
                     export { method_56 as method };
                 }
                 export namespace pixCreateCharge {
-                    const route_57: string;
+                    let route_57: string;
                     export { route_57 as route };
-                    const method_57: string;
+                    let method_57: string;
                     export { method_57 as method };
                 }
                 export namespace pixUpdateCharge {
-                    const route_58: string;
+                    let route_58: string;
                     export { route_58 as route };
-                    const method_58: string;
+                    let method_58: string;
                     export { method_58 as method };
                 }
                 export namespace pixCreateImmediateCharge {
-                    const route_59: string;
+                    let route_59: string;
                     export { route_59 as route };
-                    const method_59: string;
+                    let method_59: string;
                     export { method_59 as method };
                 }
                 export namespace pixDetailCharge {
-                    const route_60: string;
+                    let route_60: string;
                     export { route_60 as route };
-                    const method_60: string;
+                    let method_60: string;
                     export { method_60 as method };
                 }
                 export namespace pixListCharges {
-                    const route_61: string;
+                    let route_61: string;
                     export { route_61 as route };
-                    const method_61: string;
+                    let method_61: string;
                     export { method_61 as method };
                 }
                 export namespace pixDetailReceived {
-                    const route_62: string;
+                    let route_62: string;
                     export { route_62 as route };
-                    const method_62: string;
+                    let method_62: string;
                     export { method_62 as method };
                 }
                 export namespace pixReceivedList {
-                    const route_63: string;
+                    let route_63: string;
                     export { route_63 as route };
-                    const method_63: string;
+                    let method_63: string;
                     export { method_63 as method };
                 }
                 export namespace pixSend {
-                    const route_64: string;
+                    let route_64: string;
                     export { route_64 as route };
-                    const method_64: string;
+                    let method_64: string;
                     export { method_64 as method };
                 }
                 export namespace pixSendDetail {
-                    const route_65: string;
+                    let route_65: string;
                     export { route_65 as route };
-                    const method_65: string;
+                    let method_65: string;
                     export { method_65 as method };
                 }
                 export namespace pixSendList {
-                    const route_66: string;
+                    let route_66: string;
                     export { route_66 as route };
-                    const method_66: string;
+                    let method_66: string;
                     export { method_66 as method };
                 }
                 export namespace pixDevolution {
-                    const route_67: string;
+                    let route_67: string;
                     export { route_67 as route };
-                    const method_67: string;
+                    let method_67: string;
                     export { method_67 as method };
                 }
                 export namespace pixDetailDevolution {
-                    const route_68: string;
+                    let route_68: string;
                     export { route_68 as route };
-                    const method_68: string;
+                    let method_68: string;
                     export { method_68 as method };
                 }
                 export namespace pixConfigWebhook {
-                    const route_69: string;
+                    let route_69: string;
                     export { route_69 as route };
-                    const method_69: string;
+                    let method_69: string;
                     export { method_69 as method };
                 }
                 export namespace pixDetailWebhook {
-                    const route_70: string;
+                    let route_70: string;
                     export { route_70 as route };
-                    const method_70: string;
+                    let method_70: string;
                     export { method_70 as method };
                 }
                 export namespace pixListWebhook {
-                    const route_71: string;
+                    let route_71: string;
                     export { route_71 as route };
-                    const method_71: string;
+                    let method_71: string;
                     export { method_71 as method };
                 }
                 export namespace pixDeleteWebhook {
-                    const route_72: string;
+                    let route_72: string;
                     export { route_72 as route };
-                    const method_72: string;
+                    let method_72: string;
                     export { method_72 as method };
                 }
                 export namespace pixCreateLocation {
-                    const route_73: string;
+                    let route_73: string;
                     export { route_73 as route };
-                    const method_73: string;
+                    let method_73: string;
                     export { method_73 as method };
                 }
                 export namespace pixLocationList {
-                    const route_74: string;
+                    let route_74: string;
                     export { route_74 as route };
-                    const method_74: string;
+                    let method_74: string;
                     export { method_74 as method };
                 }
                 export namespace pixDetailLocation {
-                    const route_75: string;
+                    let route_75: string;
                     export { route_75 as route };
-                    const method_75: string;
+                    let method_75: string;
                     export { method_75 as method };
                 }
                 export namespace pixGenerateQRCode {
-                    const route_76: string;
+                    let route_76: string;
                     export { route_76 as route };
-                    const method_76: string;
+                    let method_76: string;
                     export { method_76 as method };
                 }
                 export namespace pixUnlinkTxidLocation {
-                    const route_77: string;
+                    let route_77: string;
                     export { route_77 as route };
-                    const method_77: string;
+                    let method_77: string;
                     export { method_77 as method };
                 }
                 export namespace pixCreateEvp {
-                    const route_78: string;
+                    let route_78: string;
                     export { route_78 as route };
-                    const method_78: string;
+                    let method_78: string;
                     export { method_78 as method };
                 }
                 export namespace pixListEvp {
-                    const route_79: string;
+                    let route_79: string;
                     export { route_79 as route };
-                    const method_79: string;
+                    let method_79: string;
                     export { method_79 as method };
                 }
                 export namespace pixDeleteEvp {
-                    const route_80: string;
+                    let route_80: string;
                     export { route_80 as route };
-                    const method_80: string;
+                    let method_80: string;
                     export { method_80 as method };
                 }
                 export namespace getAccountBalance {
-                    const route_81: string;
+                    let route_81: string;
                     export { route_81 as route };
-                    const method_81: string;
+                    let method_81: string;
                     export { method_81 as method };
                 }
                 export namespace updateAccountConfig {
-                    const route_82: string;
+                    let route_82: string;
                     export { route_82 as route };
-                    const method_82: string;
+                    let method_82: string;
                     export { method_82 as method };
                 }
                 export namespace listAccountConfig {
-                    const route_83: string;
+                    let route_83: string;
                     export { route_83 as route };
-                    const method_83: string;
+                    let method_83: string;
                     export { method_83 as method };
                 }
                 export namespace pixSplitDetailCharge {
-                    const route_84: string;
+                    let route_84: string;
                     export { route_84 as route };
-                    const method_84: string;
+                    let method_84: string;
                     export { method_84 as method };
                 }
                 export namespace pixSplitLinkCharge {
-                    const route_85: string;
+                    let route_85: string;
                     export { route_85 as route };
-                    const method_85: string;
+                    let method_85: string;
                     export { method_85 as method };
                 }
                 export namespace pixSplitUnlinkCharge {
-                    const route_86: string;
+                    let route_86: string;
                     export { route_86 as route };
-                    const method_86: string;
+                    let method_86: string;
                     export { method_86 as method };
                 }
                 export namespace pixSplitDetailDueCharge {
-                    const route_87: string;
+                    let route_87: string;
                     export { route_87 as route };
-                    const method_87: string;
+                    let method_87: string;
                     export { method_87 as method };
                 }
                 export namespace pixSplitLinkDueCharge {
-                    const route_88: string;
+                    let route_88: string;
                     export { route_88 as route };
-                    const method_88: string;
+                    let method_88: string;
                     export { method_88 as method };
                 }
                 export namespace pixSplitUnlinkDueCharge {
-                    const route_89: string;
+                    let route_89: string;
                     export { route_89 as route };
-                    const method_89: string;
+                    let method_89: string;
                     export { method_89 as method };
                 }
                 export namespace pixSplitConfig {
-                    const route_90: string;
+                    let route_90: string;
                     export { route_90 as route };
-                    const method_90: string;
+                    let method_90: string;
                     export { method_90 as method };
                 }
                 export namespace pixSplitConfigId {
-                    const route_91: string;
+                    let route_91: string;
                     export { route_91 as route };
-                    const method_91: string;
+                    let method_91: string;
                     export { method_91 as method };
                 }
                 export namespace pixSplitDetailConfig {
-                    const route_92: string;
+                    let route_92: string;
                     export { route_92 as route };
-                    const method_92: string;
+                    let method_92: string;
                     export { method_92 as method };
                 }
                 export namespace pixSendDetailId {
-                    const route_93: string;
+                    let route_93: string;
                     export { route_93 as route };
-                    const method_93: string;
+                    let method_93: string;
                     export { method_93 as method };
                 }
                 export namespace pixCreateDueChargeBatch {
-                    const route_94: string;
+                    let route_94: string;
                     export { route_94 as route };
-                    const method_94: string;
+                    let method_94: string;
                     export { method_94 as method };
                 }
                 export namespace pixUpdateDueChargeBatch {
-                    const route_95: string;
+                    let route_95: string;
                     export { route_95 as route };
-                    const method_95: string;
+                    let method_95: string;
                     export { method_95 as method };
                 }
                 export namespace pixDetailDueChargeBatch {
-                    const route_96: string;
+                    let route_96: string;
                     export { route_96 as route };
-                    const method_96: string;
+                    let method_96: string;
                     export { method_96 as method };
                 }
                 export namespace pixListDueChargeBatch {
-                    const route_97: string;
+                    let route_97: string;
                     export { route_97 as route };
-                    const method_97: string;
+                    let method_97: string;
                     export { method_97 as method };
                 }
                 export namespace medDefense {
-                    const route_98: string;
+                    let route_98: string;
                     export { route_98 as route };
-                    const method_98: string;
+                    let method_98: string;
                     export { method_98 as method };
                 }
                 export namespace medList {
-                    const route_99: string;
+                    let route_99: string;
                     export { route_99 as route };
-                    const method_99: string;
+                    let method_99: string;
                     export { method_99 as method };
                 }
             }
@@ -621,108 +621,108 @@ declare namespace _default {
         }
         namespace OPENFINANCE {
             export namespace URL_2 {
-                const PRODUCTION_2: string;
+                let PRODUCTION_2: string;
                 export { PRODUCTION_2 as PRODUCTION };
-                const SANDBOX_2: string;
+                let SANDBOX_2: string;
                 export { SANDBOX_2 as SANDBOX };
             }
             export { URL_2 as URL };
             export namespace ENDPOINTS_2 {
                 export namespace authorize_2 {
-                    const route_100: string;
+                    let route_100: string;
                     export { route_100 as route };
-                    const method_100: string;
+                    let method_100: string;
                     export { method_100 as method };
                 }
                 export { authorize_2 as authorize };
                 export namespace ofListParticipants {
-                    const route_101: string;
+                    let route_101: string;
                     export { route_101 as route };
-                    const method_101: string;
+                    let method_101: string;
                     export { method_101 as method };
                 }
                 export namespace ofStartPixPayment {
-                    const route_102: string;
+                    let route_102: string;
                     export { route_102 as route };
-                    const method_102: string;
+                    let method_102: string;
                     export { method_102 as method };
                 }
                 export namespace ofListPixPayment {
-                    const route_103: string;
+                    let route_103: string;
                     export { route_103 as route };
-                    const method_103: string;
+                    let method_103: string;
                     export { method_103 as method };
                 }
                 export namespace ofConfigUpdate {
-                    const route_104: string;
+                    let route_104: string;
                     export { route_104 as route };
-                    const method_104: string;
+                    let method_104: string;
                     export { method_104 as method };
                 }
                 export namespace ofConfigDetail {
-                    const route_105: string;
+                    let route_105: string;
                     export { route_105 as route };
-                    const method_105: string;
+                    let method_105: string;
                     export { method_105 as method };
                 }
                 export namespace ofDevolutionPix {
-                    const route_106: string;
+                    let route_106: string;
                     export { route_106 as route };
-                    const method_106: string;
+                    let method_106: string;
                     export { method_106 as method };
                 }
                 export namespace ofCancelSchedulePix {
-                    const route_107: string;
+                    let route_107: string;
                     export { route_107 as route };
-                    const method_107: string;
+                    let method_107: string;
                     export { method_107 as method };
                 }
                 export namespace ofListSchedulePixPayment {
-                    const route_108: string;
+                    let route_108: string;
                     export { route_108 as route };
-                    const method_108: string;
+                    let method_108: string;
                     export { method_108 as method };
                 }
                 export namespace ofStartSchedulePixPayment {
-                    const route_109: string;
+                    let route_109: string;
                     export { route_109 as route };
-                    const method_109: string;
+                    let method_109: string;
                     export { method_109 as method };
                 }
                 export namespace ofDevolutionSchedulePix {
-                    const route_110: string;
+                    let route_110: string;
                     export { route_110 as route };
-                    const method_110: string;
+                    let method_110: string;
                     export { method_110 as method };
                 }
                 export namespace ofStartRecurrencyPixPayment {
-                    const route_111: string;
+                    let route_111: string;
                     export { route_111 as route };
-                    const method_111: string;
+                    let method_111: string;
                     export { method_111 as method };
                 }
                 export namespace ofListRecurrencyPixPayment {
-                    const route_112: string;
+                    let route_112: string;
                     export { route_112 as route };
-                    const method_112: string;
+                    let method_112: string;
                     export { method_112 as method };
                 }
                 export namespace ofCancelRecurrencyPix {
-                    const route_113: string;
+                    let route_113: string;
                     export { route_113 as route };
-                    const method_113: string;
+                    let method_113: string;
                     export { method_113 as method };
                 }
                 export namespace ofDevolutionRecurrencyPix {
-                    const route_114: string;
+                    let route_114: string;
                     export { route_114 as route };
-                    const method_114: string;
+                    let method_114: string;
                     export { method_114 as method };
                 }
                 export namespace ofReplaceRecurrencyPixParcel {
-                    const route_115: string;
+                    let route_115: string;
                     export { route_115 as route };
-                    const method_115: string;
+                    let method_115: string;
                     export { method_115 as method };
                 }
             }
@@ -730,42 +730,42 @@ declare namespace _default {
         }
         namespace PAGAMENTOS {
             export namespace URL_3 {
-                const PRODUCTION_3: string;
+                let PRODUCTION_3: string;
                 export { PRODUCTION_3 as PRODUCTION };
-                const SANDBOX_3: string;
+                let SANDBOX_3: string;
                 export { SANDBOX_3 as SANDBOX };
             }
             export { URL_3 as URL };
             export namespace ENDPOINTS_3 {
                 export namespace authorize_3 {
-                    const route_116: string;
+                    let route_116: string;
                     export { route_116 as route };
-                    const method_116: string;
+                    let method_116: string;
                     export { method_116 as method };
                 }
                 export { authorize_3 as authorize };
                 export namespace payDetailBarCode {
-                    const route_117: string;
+                    let route_117: string;
                     export { route_117 as route };
-                    const method_117: string;
+                    let method_117: string;
                     export { method_117 as method };
                 }
                 export namespace payRequestBarCode {
-                    const route_118: string;
+                    let route_118: string;
                     export { route_118 as route };
-                    const method_118: string;
+                    let method_118: string;
                     export { method_118 as method };
                 }
                 export namespace payDetailPayment {
-                    const route_119: string;
+                    let route_119: string;
                     export { route_119 as route };
-                    const method_119: string;
+                    let method_119: string;
                     export { method_119 as method };
                 }
                 export namespace payListPayments {
-                    const route_120: string;
+                    let route_120: string;
                     export { route_120 as route };
-                    const method_120: string;
+                    let method_120: string;
                     export { method_120 as method };
                 }
             }
@@ -773,60 +773,60 @@ declare namespace _default {
         }
         namespace CONTAS {
             export namespace URL_4 {
-                const PRODUCTION_4: string;
+                let PRODUCTION_4: string;
                 export { PRODUCTION_4 as PRODUCTION };
-                const SANDBOX_4: string;
+                let SANDBOX_4: string;
                 export { SANDBOX_4 as SANDBOX };
             }
             export { URL_4 as URL };
             export namespace ENDPOINTS_4 {
                 export namespace authorize_4 {
-                    const route_121: string;
+                    let route_121: string;
                     export { route_121 as route };
-                    const method_121: string;
+                    let method_121: string;
                     export { method_121 as method };
                 }
                 export { authorize_4 as authorize };
                 export namespace createAccount {
-                    const route_122: string;
+                    let route_122: string;
                     export { route_122 as route };
-                    const method_122: string;
+                    let method_122: string;
                     export { method_122 as method };
                 }
                 export namespace getAccountCertificate {
-                    const route_123: string;
+                    let route_123: string;
                     export { route_123 as route };
-                    const method_123: string;
+                    let method_123: string;
                     export { method_123 as method };
                 }
                 export namespace getAccountCredentials {
-                    const route_124: string;
+                    let route_124: string;
                     export { route_124 as route };
-                    const method_124: string;
+                    let method_124: string;
                     export { method_124 as method };
                 }
                 export namespace accountConfigWebhook {
-                    const route_125: string;
+                    let route_125: string;
                     export { route_125 as route };
-                    const method_125: string;
+                    let method_125: string;
                     export { method_125 as method };
                 }
                 export namespace accountDeleteWebhook {
-                    const route_126: string;
+                    let route_126: string;
                     export { route_126 as route };
-                    const method_126: string;
+                    let method_126: string;
                     export { method_126 as method };
                 }
                 export namespace accountDetailWebhook {
-                    const route_127: string;
+                    let route_127: string;
                     export { route_127 as route };
-                    const method_127: string;
+                    let method_127: string;
                     export { method_127 as method };
                 }
                 export namespace accountListWebhook {
-                    const route_128: string;
+                    let route_128: string;
                     export { route_128 as route };
-                    const method_128: string;
+                    let method_128: string;
                     export { method_128 as method };
                 }
             }

--- a/dist/types/methods/abertura.d.ts
+++ b/dist/types/methods/abertura.d.ts
@@ -51,7 +51,7 @@ export class OpenAccountMethods extends PagamentoDeContasMethods {
             razaoSocial?: string;
             endereco: {
                 cep: string;
-                estado: 'AC' | 'AL' | 'AP' | 'AM' | 'BA' | 'CE' | 'DF' | 'ES' | 'GO' | 'MA' | 'MT' | 'MS' | 'MG' | 'PA' | 'PB' | 'PR' | 'PE' | 'PI' | 'RJ' | 'RN' | 'RS' | 'RO' | 'RR' | 'SC' | 'SP' | 'SE' | 'TO';
+                estado: "AC" | "AL" | "AP" | "AM" | "BA" | "CE" | "DF" | "ES" | "GO" | "MA" | "MT" | "MS" | "MG" | "PA" | "PB" | "PR" | "PE" | "PI" | "RJ" | "RN" | "RS" | "RO" | "RR" | "SC" | "SP" | "SE" | "TO";
                 cidade: string;
                 bairro: string;
                 logradouro: string;
@@ -59,7 +59,7 @@ export class OpenAccountMethods extends PagamentoDeContasMethods {
                 complemento?: string;
             };
         };
-        meioDeNotificacao: Array<'sms' | 'whatsapp'>;
+        meioDeNotificacao: Array<"sms" | "whatsapp">;
         escoposIntegrados: Array<string>;
     }): Promise<{
         contaSimplificada: {
@@ -229,7 +229,7 @@ export class OpenAccountMethods extends PagamentoDeContasMethods {
     accountDeleteWebhook(params: {
         identificadorWebhook: string;
     }): Promise<{
-        void;
+        void: any;
     }>;
 }
 import { PagamentoDeContasMethods } from "./pagamento-de-contas";

--- a/dist/types/methods/cobrancas.d.ts
+++ b/dist/types/methods/cobrancas.d.ts
@@ -191,11 +191,11 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 expire_at: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 conditional_discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                     until_date: string;
                 };
@@ -204,7 +204,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     fine?: number;
                     interest?: {
                         value: number;
-                        type: 'monthly' | 'daily';
+                        type: "monthly" | "daily";
                     } | number;
                 };
                 message?: string;
@@ -232,7 +232,7 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 installments: number;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 billing_address?: {
@@ -495,11 +495,11 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 expire_at: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 conditional_discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                     until_date: string;
                 };
@@ -508,7 +508,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     fine?: number;
                     interest?: {
                         value: number;
-                        type: 'monthly' | 'daily';
+                        type: "monthly" | "daily";
                     } | number;
                 };
                 message?: string;
@@ -536,7 +536,7 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 installments: number;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 billing_address: {
@@ -572,7 +572,7 @@ export class CobrancasMethods extends ExtratosMethods {
             expire_at?: string;
             configurations?: {
                 days_to_write_off: number;
-                interest_type?: 'monthly' | 'daily';
+                interest_type?: "monthly" | "daily";
                 interest?: number;
                 fine?: number;
             };
@@ -782,7 +782,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     expire_at: string;
                     configurations?: {
                         days_to_write_off?: number;
-                        interest_type?: 'monthly' | 'daily';
+                        interest_type?: "monthly" | "daily";
                         interest?: number;
                         fine?: number;
                     };
@@ -888,9 +888,9 @@ export class CobrancasMethods extends ExtratosMethods {
     listCharges(params: {
         begin_date: string;
         end_date: string;
-        charge_type: 'billet' | 'card' | 'carnet' | 'subscription';
-        status?: 'new' | 'waiting' | 'link' | 'paid' | 'unpaid' | 'canceled' | 'identified' | 'settled';
-        date_of?: 'creation' | 'payment' | 'expired';
+        charge_type: "billet" | "card" | "carnet" | "subscription";
+        status?: "new" | "waiting" | "link" | "paid" | "unpaid" | "canceled" | "identified" | "settled";
+        date_of?: "creation" | "payment" | "expired";
         customer_document?: string;
         custom_id?: string;
         value?: number;
@@ -934,7 +934,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     link: string;
                     configurations: {
                         days_to_write_off: number;
-                        interest_type?: 'monthly' | 'daily';
+                        interest_type?: "monthly" | "daily";
                         interest: number;
                         fine: number;
                     };
@@ -947,12 +947,12 @@ export class CobrancasMethods extends ExtratosMethods {
                 billet_discount: number | null;
                 card_discount: number | null;
                 conditional_discount_value: number | null;
-                conditional_discount_type: 'percentage' | 'currency' | null;
+                conditional_discount_type: "percentage" | "currency" | null;
                 conditional_discount_date: string | null;
                 message: string | null;
                 expire_at: string;
                 request_delivery_address: boolean;
-                payment_method: 'banking_billet' | 'credit_card' | 'all';
+                payment_method: "banking_billet" | "credit_card" | "all";
                 payment_url: string;
             };
         }>;
@@ -1275,7 +1275,7 @@ export class CobrancasMethods extends ExtratosMethods {
      */
     getInstallments(params: {
         total: number;
-        brand: 'visa' | 'mastercard' | 'amex' | 'elo' | 'hipercard';
+        brand: "visa" | "mastercard" | "amex" | "elo" | "hipercard";
     }): Promise<{
         code: number;
         data: {
@@ -1421,16 +1421,16 @@ export class CobrancasMethods extends ExtratosMethods {
             fine?: number;
             interest?: {
                 value: number;
-                type: 'monthly' | 'daily';
+                type: "monthly" | "daily";
             } | number;
         };
         message?: string;
         discount?: {
-            type: 'percentage' | 'currency';
+            type: "percentage" | "currency";
             value: number;
         };
         conditional_discount?: {
-            type: 'percentage' | 'currency';
+            type: "percentage" | "currency";
             value: number;
             until_date: string;
         };
@@ -1553,7 +1553,7 @@ export class CobrancasMethods extends ExtratosMethods {
                 expire_at: string;
                 configurations?: {
                     days_to_write_off?: number;
-                    interest_type?: 'monthly' | 'daily';
+                    interest_type?: "monthly" | "daily";
                     interest?: number;
                     fine?: number;
                 };
@@ -2092,11 +2092,11 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 expire_at: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 conditional_discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                     until_date: string;
                 };
@@ -2104,7 +2104,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     fine?: number;
                     interest?: {
                         value: number;
-                        type: 'monthly' | 'daily';
+                        type: "monthly" | "daily";
                     } | number;
                 };
                 message?: string;
@@ -2141,7 +2141,7 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 payment_token: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 message?: string;
@@ -2398,11 +2398,11 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 expire_at: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 conditional_discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                     until_date: string;
                 };
@@ -2410,7 +2410,7 @@ export class CobrancasMethods extends ExtratosMethods {
                     fine?: number;
                     interest?: {
                         value: number;
-                        type: 'monthly' | 'daily';
+                        type: "monthly" | "daily";
                     } | number;
                 };
                 message?: string;
@@ -2447,7 +2447,7 @@ export class CobrancasMethods extends ExtratosMethods {
                 };
                 payment_token: string;
                 discount?: {
-                    type: 'percentage' | 'currency';
+                    type: "percentage" | "currency";
                     value: number;
                 };
                 message?: string;
@@ -2634,14 +2634,14 @@ export class CobrancasMethods extends ExtratosMethods {
             billet_discount?: number;
             card_discount?: number;
             conditional_discount?: {
-                type: 'percentage' | 'currency';
+                type: "percentage" | "currency";
                 value: number;
                 until_date: string;
             };
             message?: string;
             expire_at: string;
             request_delivery_address: boolean;
-            payment_method: 'banking_billet' | 'credit_card' | 'all';
+            payment_method: "banking_billet" | "credit_card" | "all";
         };
     }): Promise<{
         code: number;
@@ -2942,14 +2942,14 @@ export class CobrancasMethods extends ExtratosMethods {
             billet_discount?: number;
             card_discount?: number;
             conditional_discount?: {
-                type: 'percentage' | 'currency';
+                type: "percentage" | "currency";
                 value: number;
                 until_date: string;
             };
             message?: string;
             expire_at: string;
             request_delivery_address: boolean;
-            payment_method: 'banking_billet' | 'credit_card' | 'all';
+            payment_method: "banking_billet" | "credit_card" | "all";
         };
     }): Promise<{
         code: number;
@@ -3017,14 +3017,14 @@ export class CobrancasMethods extends ExtratosMethods {
         billet_discount?: number;
         card_discount?: number;
         conditional_discount?: {
-            type: 'percentage' | 'currency';
+            type: "percentage" | "currency";
             value: number;
             until_date: string;
         };
         message?: string;
         expire_at: string;
         request_delivery_address: boolean;
-        payment_method: 'banking_billet' | 'credit_card' | 'all';
+        payment_method: "banking_billet" | "credit_card" | "all";
     }): Promise<{
         code: number;
         data: {
@@ -3036,7 +3036,7 @@ export class CobrancasMethods extends ExtratosMethods {
             payment_method: string;
             conditional_discount_date: string | null;
             conditional_discount_value?: number;
-            conditional_discount_type?: 'percentage' | 'currency';
+            conditional_discount_type?: "percentage" | "currency";
             billet_discount?: number;
             card_discount?: number;
             created_at: string;
@@ -3088,14 +3088,14 @@ export class CobrancasMethods extends ExtratosMethods {
         billet_discount?: number;
         card_discount?: number;
         conditional_discount?: {
-            type: 'percentage' | 'currency';
+            type: "percentage" | "currency";
             value: number;
             until_date: string;
         };
         message?: string;
         expire_at: string;
         request_delivery_address: boolean;
-        payment_method: 'banking_billet' | 'credit_card' | 'all';
+        payment_method: "banking_billet" | "credit_card" | "all";
     }): Promise<{
         code: number;
         data: {
@@ -3107,7 +3107,7 @@ export class CobrancasMethods extends ExtratosMethods {
             payment_method: string;
             conditional_discount_date: string | null;
             conditional_discount_value?: number;
-            conditional_discount_type?: 'percentage' | 'currency';
+            conditional_discount_type?: "percentage" | "currency";
             billet_discount?: number;
             card_discount?: number;
             created_at: string;

--- a/dist/types/methods/extratos.d.ts
+++ b/dist/types/methods/extratos.d.ts
@@ -16,7 +16,7 @@ export class ExtratosMethods {
      * }>}
      */
     listStatementFiles(): Promise<{
-        Array();
+        Array(): any;
     }>;
     /**
      * **GET /v1/extrato-cnab/download/:nome_arquivo**
@@ -55,7 +55,7 @@ export class ExtratosMethods {
      *
      */
     listStatementRecurrences(): Promise<{
-        Array();
+        Array(): any;
     }>;
     /**
      * **POST /v1/extrato-cnab/agendar**

--- a/dist/types/methods/open-finance.d.ts
+++ b/dist/types/methods/open-finance.d.ts
@@ -18,7 +18,7 @@ export class OpenFinanceMethods extends PixMethods {
         redirectURL: string;
         webhookURL: string;
         webhookSecurity: {
-            type: 'mtls' | 'hmac';
+            type: "mtls" | "hmac";
         };
     }>;
     /**
@@ -56,15 +56,15 @@ export class OpenFinanceMethods extends PixMethods {
         redirectURL: string;
         webhookURL: string;
         webhookSecurity?: {
-            type: 'mtls' | 'hmac';
+            type: "mtls" | "hmac";
             hash?: string;
         };
-        processPayment?: 'async' | 'sync';
+        processPayment?: "async" | "sync";
     }): Promise<{
         redirectURL: string;
         webhookURL: string;
         webhookSecurity: {
-            type: 'mtls' | 'hmac';
+            type: "mtls" | "hmac";
             hash?: string;
         };
     }>;
@@ -100,8 +100,8 @@ export class OpenFinanceMethods extends PixMethods {
     ofListParticipants(params: {
         nome?: string;
         organizacao?: boolean;
-        modalidade?: 'imediato' | 'recorrente' | 'agendado';
-        tipoPessoa?: 'PJ' | 'PF';
+        modalidade?: "imediato" | "recorrente" | "agendado";
+        tipoPessoa?: "PJ" | "PF";
     }): Promise<{
         participantes: Array<{
             identificador: string;
@@ -306,7 +306,7 @@ export class OpenFinanceMethods extends PixMethods {
                 agencia: string;
                 documento: string;
                 nome: string;
-                tipoConta: 'CACC' | 'SLRY' | 'SVGS' | 'TRAN';
+                tipoConta: "CACC" | "SLRY" | "SVGS" | "TRAN";
             };
         };
         pagamento: {
@@ -512,7 +512,7 @@ export class OpenFinanceMethods extends PixMethods {
                 agencia: string;
                 documento: string;
                 nome: string;
-                tipoConta: 'CACC' | 'SLRY' | 'SVGS' | 'TRAN';
+                tipoConta: "CACC" | "SLRY" | "SVGS" | "TRAN";
             };
         };
         pagamento: {
@@ -521,7 +521,7 @@ export class OpenFinanceMethods extends PixMethods {
             infoPagador?: string;
             idProprio?: string;
             recorrencia: {
-                tipo: 'diaria' | 'semanal' | 'mensal' | 'personalizada';
+                tipo: "diaria" | "semanal" | "mensal" | "personalizada";
                 dataInicio?: string;
                 quantidade?: number;
                 diaDaSemana?: string;

--- a/dist/types/methods/pagamento-de-contas.d.ts
+++ b/dist/types/methods/pagamento-de-contas.d.ts
@@ -60,7 +60,7 @@ export class PagamentoDeContasMethods extends OpenFinanceMethods {
     payDetailBarCode(params: {
         codBarras: string;
     }): Promise<{
-        tipo: 'boleto' | 'tributo';
+        tipo: "boleto" | "tributo";
         banco: {
             codigo: number;
             nome: string;

--- a/dist/types/methods/pix.d.ts
+++ b/dist/types/methods/pix.d.ts
@@ -1764,7 +1764,7 @@ export class PixMethods extends CobrancasMethods {
      * }>}
      */
     pixCreateLocation(params: any, body: {
-        tipoCob: 'cob' | 'cobv';
+        tipoCob: "cob" | "cobv";
     }): Promise<{
         id: number;
         location: string;
@@ -3170,7 +3170,7 @@ export class PixMethods extends CobrancasMethods {
             chave?: string;
             status: "ABERTA" | "ACEITA" | "CANCELADA_EFI" | "EM_DEFESA" | "REJEITADA";
             razao: string;
-            tipoSituacao?: "golpe" | "aquisição da conta" | "coerção" | "acesso fraudulento" | "outro" | "desconhecido";
+            tipoSituacao?: "golpe" | "aquisi\u00E7\u00E3o da conta" | "coer\u00E7\u00E3o" | "acesso fraudulento" | "outro" | "desconhecido";
             tipoFraude?: string;
             comentario?: string;
             defesa?: string;
@@ -3339,7 +3339,7 @@ export class PixMethods extends CobrancasMethods {
      *
      */
     pixResendWebhook(params: {}, body: {
-        tipo: 'PIX_RECEBIDO' | 'PIX_ENVIADO' | 'DEVOLUCAO_RECEBIDA' | 'DEVOLUCAO_ENVIADA';
+        tipo: "PIX_RECEBIDO" | "PIX_ENVIADO" | "DEVOLUCAO_RECEBIDA" | "DEVOLUCAO_ENVIADA";
         e2eids: Array<string>;
     }): Promise<void>;
 }

--- a/fix-types.js
+++ b/fix-types.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const typesPath = path.join(__dirname, 'dist', 'types', 'index.d.ts');
+
+if (fs.existsSync(typesPath)) {
+    let content = fs.readFileSync(typesPath, 'utf8');
+    
+    // Convert 'export default class EfiPay' to 'declare class EfiPay'
+    // and append 'export = EfiPay;' to ensure compatibility with NodeNext + ESM/CJS default imports
+    if (content.includes('export default class EfiPay')) {
+        content = content.replace('export default class EfiPay', 'declare class EfiPay');
+        content += '\nexport = EfiPay;\n';
+        fs.writeFileSync(typesPath, content);
+        console.log('Fixed types in dist/types/index.d.ts');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@rollup/plugin-json": "^6.1.0",
 				"prettier": "^3.0.3",
 				"rollup": "^2.52.3",
-				"typescript": "^4.3.5",
+				"typescript": "^5.9.3",
 				"undici": "^6.19.2"
 			}
 		},
@@ -2477,16 +2477,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici": {
@@ -4259,9 +4260,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true
 		},
 		"undici": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"exports": {
 		".": {
 			"require": "./dist/cjs/index.cjs",
-			"import": "./dist/cjs/index.cjs",
+			"import": "./dist/esm/index.mjs",
 			"types": "./dist/types/index.d.ts"
 		}
 	},
@@ -40,6 +40,7 @@
 	"scripts": {
 		"start": "node app.js",
 		"build": "rollup -c && tsc --project tsconfig.json",
+		"postbuild": "node fix-types.js",
 		"test": "./node_modules/.bin/jest",
 		"test-cov": "./node_modules/.bin/jest --coverage"
 	},
@@ -50,7 +51,7 @@
 		"@rollup/plugin-json": "^6.1.0",
 		"prettier": "^3.0.3",
 		"rollup": "^2.52.3",
-		"typescript": "^4.3.5",
+		"typescript": "^5.9.3",
 		"undici": "^6.19.2"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,14 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
+    "moduleResolution": "Bundler",
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist/types",
     "allowJs": true,
     "checkJs": true,
     "strict": true,
-    "moduleResolution": "node"
+    "rootDir": "src"
   },
   "include": ["src/**/*.js"]
 }


### PR DESCRIPTION
## Descrição
Este PR resolve o erro de tipagem que impedia a instanciação da classe EfiPay em repositórios configurados com módulos ESM nativos e NodeNext. Além disso, a versão do TypeScript do SDK foi atualizada para a `v5.x` e as configurações do compilador foram modernizadas, adotando a resolução de módulos `Bundler`.

## Mudanças
- Adicionado o arquivo de script auxiliar `fix-types.js` que adapta o arquivo `.d.ts` final com um `export = EfiPay`, unificando a compatibilidade de importe CJS e ESM.
- Atualizado o mapeamento da diretiva `"exports"` no `package.json` para que as importações do tipo (`import`) resolvam corretamente a compilação ESM em `./dist/esm/index.mjs`.
- Adicionado a rotina `"postbuild"` no `package.json` para executar o script de adequação de tipos no Rollup de forma automatizada.
- A versão de desenvolvimento orgânica (`devDependencies`) do `typescript` subiu para a nova versão `^5.9.3` no `package.json`.
- Refatorado o `tsconfig.json` para utilizar `rootDir: "src"` e modernizado a estratégia de módulos para `moduleResolution: "Bundler"`, suprimindo consequentemente os *warnings* de features descontinuadas.
